### PR TITLE
changed app.CommonConfig.name from static-thumbnails to static_thumbn…

### DIFF
--- a/static_thumbnails/apps.py
+++ b/static_thumbnails/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class CommonConfig(AppConfig):
-    name = 'static-thumbnails'
+    name = 'static_thumbnails'


### PR DESCRIPTION
…ails due to Error: django.core.exceptions.ImproperlyConfigured: Cannot import 'static-thumbnails'. Check that 'static_thumbnails.apps.CommonConfig.name' is correct. in Django 4